### PR TITLE
Fix typo in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if range.include?(range2)
   # ...
 end
 
-if range.overlaps(range2)
+if range.overlaps?(range2)
   range3 = range.overlap(range2)
 end
 ```


### PR DESCRIPTION
The code example in the README was missing the `?` in the `overlaps?` method call.